### PR TITLE
Add ProxyShutdownEvent

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/ProxyShutdownEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ProxyShutdownEvent.java
@@ -1,0 +1,17 @@
+package net.md_5.bungee.api.event;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.plugin.Event;
+
+/**
+ * This event is fired when the proxy is shutting down before players are disconnected
+ */
+@Getter
+@EqualsAndHashCode(callSuper = false)
+public class ProxyShutdownEvent extends Event
+{
+
+}

--- a/api/src/main/java/net/md_5/bungee/api/event/ProxyShutdownEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ProxyShutdownEvent.java
@@ -9,7 +9,7 @@ import net.md_5.bungee.api.plugin.Event;
 /**
  * This event is fired when the proxy is shutting down before players are disconnected
  */
-@Getter
+@ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
 public class ProxyShutdownEvent extends Event
 {

--- a/api/src/main/java/net/md_5/bungee/api/event/ProxyShutdownEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ProxyShutdownEvent.java
@@ -1,9 +1,7 @@
 package net.md_5.bungee.api.event;
 
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import net.md_5.bungee.api.CommandSender;
+import lombok.ToString;
 import net.md_5.bungee.api.plugin.Event;
 
 /**

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -68,6 +68,7 @@ import net.md_5.bungee.api.config.ConfigurationAdapter;
 import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.ProxyShutdownEvent;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
 import net.md_5.bungee.chat.ComponentSerializer;
@@ -458,6 +459,8 @@ public class BungeeCord extends ProxyServer
         }
         isRunning = false;
 
+        getPluginManager().callEvent( new ProxyShutdownEvent() );
+        
         stopListeners();
         getLogger().info( "Closing pending connections" );
 


### PR DESCRIPTION
This allows plugins to transfer players to a different server with the ProxiedPlayer#transfer() API on proxy shutdown
This is currently not possible